### PR TITLE
feat: add IngestionQueue and DLQ, wire into WebhookLambdaConstruct

### DIFF
--- a/lib/constructs/ingestion_queue_construct.ts
+++ b/lib/constructs/ingestion_queue_construct.ts
@@ -27,7 +27,6 @@ export interface IngestionQueueConstructProps {
  * IngestionQueueConstruct
  */
 export class IngestionQueueConstruct extends Construct {
-  
   public readonly queue: sqs.Queue;
 
   public readonly dlq: sqs.Queue;
@@ -48,7 +47,7 @@ export class IngestionQueueConstruct extends Construct {
       retentionPeriod = cdk.Duration.days(4),
     } = props;
 
-    // Dead-Letter Queue 
+    // Dead-Letter Queue
     this.dlq = new sqs.Queue(this, "IngestionDLQ", {
       queueName: "IngestionDLQ",
       retentionPeriod: cdk.Duration.days(14),

--- a/lib/constructs/ingestion_queue_construct.ts
+++ b/lib/constructs/ingestion_queue_construct.ts
@@ -1,0 +1,104 @@
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cloudwatch_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export interface IngestionQueueConstructProps {
+  /**
+   * SNS topic to notify when messages land in the DLQ.
+   * If omitted, the alarm is still created but no notification action is wired.
+   */
+  alarmTopic?: sns.ITopic;
+
+  /**
+   * Maximum number of receive attempts before a message is moved to the DLQ.
+   */
+  maxReceiveCount?: number;
+
+  /**
+   * How long the main IngestionQueue retains unprocessed messages.
+   */
+  retentionPeriod?: cdk.Duration;
+}
+
+/**
+ * IngestionQueueConstruct
+ */
+export class IngestionQueueConstruct extends Construct {
+  
+  public readonly queue: sqs.Queue;
+
+  public readonly dlq: sqs.Queue;
+
+  /** CloudWatch alarm **/
+  public readonly dlqAlarm: cloudwatch.Alarm;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: IngestionQueueConstructProps = {},
+  ) {
+    super(scope, id);
+
+    const {
+      alarmTopic,
+      maxReceiveCount = 3,
+      retentionPeriod = cdk.Duration.days(4),
+    } = props;
+
+    // Dead-Letter Queue 
+    this.dlq = new sqs.Queue(this, "IngestionDLQ", {
+      queueName: "IngestionDLQ",
+      retentionPeriod: cdk.Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED,
+    });
+
+    // Main Ingestion Queue
+    this.queue = new sqs.Queue(this, "IngestionQueue", {
+      queueName: "IngestionQueue",
+      retentionPeriod,
+      visibilityTimeout: cdk.Duration.minutes(5),
+      encryption: sqs.QueueEncryption.SQS_MANAGED,
+      deadLetterQueue: {
+        queue: this.dlq,
+        maxReceiveCount,
+      },
+    });
+
+    // ── DLQ CloudWatch Alarm ─────────────────────────────────────────────────
+    // Threshold = 1: any DLQ depth > 0 is always worth investigating immediately.
+    this.dlqAlarm = new cloudwatch.Alarm(this, "DLQDepthAlarm", {
+      alarmName: "IngestionDLQ-MessagesVisible",
+      alarmDescription:
+        "One or more messages have been dead-lettered. " +
+        "Investigate, apply a fix, then redrive or discard.",
+      metric: this.dlq.metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(1),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    if (alarmTopic) {
+      this.dlqAlarm.addAlarmAction(
+        new cloudwatch_actions.SnsAction(alarmTopic),
+      );
+    }
+
+    new cdk.CfnOutput(this, "IngestionQueueUrl", {
+      value: this.queue.queueUrl,
+      description: "URL of the main Ingestion SQS Queue",
+    });
+
+    new cdk.CfnOutput(this, "IngestionDLQUrl", {
+      value: this.dlq.queueUrl,
+      description: "URL of the Ingestion Dead-Letter Queue",
+    });
+  }
+}

--- a/lib/constructs/ingestion_queue_construct.ts
+++ b/lib/constructs/ingestion_queue_construct.ts
@@ -49,14 +49,14 @@ export class IngestionQueueConstruct extends Construct {
 
     // Dead-Letter Queue
     this.dlq = new sqs.Queue(this, "IngestionDLQ", {
-      queueName: "IngestionDLQ",
+      queueName: `${cdk.Stack.of(this).stackName}-IngestionDLQ`,
       retentionPeriod: cdk.Duration.days(14),
       encryption: sqs.QueueEncryption.SQS_MANAGED,
     });
 
     // Main Ingestion Queue
     this.queue = new sqs.Queue(this, "IngestionQueue", {
-      queueName: "IngestionQueue",
+      queueName: `${cdk.Stack.of(this).stackName}-IngestionQueue`,
       retentionPeriod,
       visibilityTimeout: cdk.Duration.minutes(5),
       encryption: sqs.QueueEncryption.SQS_MANAGED,
@@ -69,7 +69,7 @@ export class IngestionQueueConstruct extends Construct {
     // ── DLQ CloudWatch Alarm ─────────────────────────────────────────────────
     // Threshold = 1: any DLQ depth > 0 is always worth investigating immediately.
     this.dlqAlarm = new cloudwatch.Alarm(this, "DLQDepthAlarm", {
-      alarmName: "IngestionDLQ-MessagesVisible",
+      alarmName: `${cdk.Stack.of(this).stackName}-IngestionDLQ-MessagesVisible`,
       alarmDescription:
         "One or more messages have been dead-lettered. " +
         "Investigate, apply a fix, then redrive or discard.",

--- a/lib/constructs/webhook_lamda_construct.ts
+++ b/lib/constructs/webhook_lamda_construct.ts
@@ -57,8 +57,7 @@ export default class WebhookLambdaConstruct extends Construct {
     });
 
     props.documentBucket.grantReadWrite(webhookListenerFn);
-    props.ingestionQueue.grantSendMessages(webhookListenerFn);  
-
+    props.ingestionQueue.grantSendMessages(webhookListenerFn);
 
     const fnUrl = webhookListenerFn.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,

--- a/lib/constructs/webhook_lamda_construct.ts
+++ b/lib/constructs/webhook_lamda_construct.ts
@@ -2,6 +2,7 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as cdk from "aws-cdk-lib";
 import * as path from "path";
+import * as sqs from "aws-cdk-lib/aws-sqs";
 import { Construct } from "constructs";
 
 export interface WebhookLambdaConstructProps {
@@ -25,6 +26,11 @@ export interface WebhookLambdaConstructProps {
    * Environment Variables
    */
   environmentVariables: { [key: string]: string };
+
+  /**
+   * Ingestion Queue
+   */
+  ingestionQueue: sqs.IQueue;
 }
 
 export default class WebhookLambdaConstruct extends Construct {
@@ -45,11 +51,14 @@ export default class WebhookLambdaConstruct extends Construct {
       environment: {
         ...props.environmentVariables,
         DOCUMENT_BUCKET: props.documentBucket.bucketName,
+        INGESTION_QUEUE_URL: props.ingestionQueue.queueUrl,
       },
       description: props.description,
     });
 
     props.documentBucket.grantReadWrite(webhookListenerFn);
+    props.ingestionQueue.grantSendMessages(webhookListenerFn);  
+
 
     const fnUrl = webhookListenerFn.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,

--- a/lib/stacks/blueprint_chat_cdk-stack.ts
+++ b/lib/stacks/blueprint_chat_cdk-stack.ts
@@ -3,6 +3,7 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import LambdaLlmProxyConstruct from "../constructs/lambda_llm_proxy_construct";
 import WebhookLambdaConstruct from "../constructs/webhook_lamda_construct";
+import { IngestionQueueConstruct } from "../constructs/ingestion_queue_construct";
 
 export interface BlueprintChatCdkStackProps extends cdk.StackProps {
   NOTION_API_KEY: string;
@@ -23,6 +24,8 @@ export class BlueprintChatCdkStack extends cdk.Stack {
       monthlyLimit: 6.6,
     });
 
+    const ingestion = new IngestionQueueConstruct(this, "Ingestion");
+
     // Notion
     new WebhookLambdaConstruct(this, "NotionWebhookLambda", {
       codePath: "functions/webhook-listener-notion-lambda",
@@ -32,6 +35,7 @@ export class BlueprintChatCdkStack extends cdk.Stack {
       environmentVariables: {
         NOTION_API_KEY: props.NOTION_API_KEY,
       },
+      ingestionQueue: ingestion.queue,
     });
 
     // Discord
@@ -43,6 +47,7 @@ export class BlueprintChatCdkStack extends cdk.Stack {
       environmentVariables: {
         DISCORD_API_KEY: props.DISCORD_API_KEY,
       },
+      ingestionQueue: ingestion.queue,
     });
 
     // Google Drive
@@ -54,6 +59,7 @@ export class BlueprintChatCdkStack extends cdk.Stack {
       environmentVariables: {
         DRIVE_API_KEY: props.DRIVE_API_KEY,
       },
+      ingestionQueue: ingestion.queue,
     });
 
     // Wiki
@@ -65,6 +71,7 @@ export class BlueprintChatCdkStack extends cdk.Stack {
       environmentVariables: {
         WIKI_API_KEY: props.WIKI_API_KEY,
       },
+      ingestionQueue: ingestion.queue,
     });
   }
 }


### PR DESCRIPTION
Introduces SQS-based queuing as the boundary between webhook ingestion and downstream processing.
Changes

Added IngestionQueueConstruct provisioning an IngestionQueue (4-day retention) and IngestionDLQ (14-day retention) with a CloudWatch alarm that fires on the first dead-lettered message
Updated WebhookLambdaConstruct to accept an ingestionQueue prop, inject INGESTION_QUEUE_URL as an environment variable, and grant SendMessage-only permissions
Webhook Lambda now validates and enqueues — no direct downstream calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced message queue infrastructure with dead-letter queue support to handle failed messages automatically.
  * Added CloudWatch monitoring for queue failures with optional SNS notifications.

* **Refactor**
  * Consolidated queue provisioning configuration into a reusable construct for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->